### PR TITLE
fix test failure when in debug mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,8 +220,14 @@ if (patchOptions.printWrappedCode) {
 // console.log(_compileStr);
 /* jshint -W061 */
 var patchedCompile;
+var _compileStrExpr = '(' + _compileStr + ')';
+
+if (global.v8debug) {
+  _compileStrExpr = 'var resolvedArgv;\n' + _compileStrExpr;
+}
+
 try {
-  patchedCompile = eval('(' + _compileStr + ')');
+  patchedCompile = eval(_compileStrExpr);
 } catch (err) {
   console.error('Problem evaluating the new compile');
   console.error(err.message);

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "size": "tarball=\"$(npm pack .)\"; wc -c \"${tarball}\"; tar tvf \"${tarball}\"; rm \"${tarball}\";",
     "test": "npm run build && npm run basic-tests && npm run cache-tests && npm run extra-tests",
     "test-args": "node test/load-arguments.js",
+    "test-debug": "node test/debug.js",
     "test-fake-example": "mocha test/fake-use/get-version-spec.js",
     "test-fakes": "node test/load-fake-json.js && node test/load-fake.js && node test/load-fake-object.js && node test/load-fake-example.js",
     "test-nested": "node test/nested-a.js",

--- a/test/debug.js
+++ b/test/debug.js
@@ -1,0 +1,9 @@
+var assert = require('assert');
+var spawn = require('child_process').spawn;
+var script = __dirname + '/simple.js';
+
+var child = spawn(process.execPath, ['--debug', script]);
+
+child.on('close', function(code) {
+  console.assert(0 === code, 'node debug should terminated successfully');
+});


### PR DESCRIPTION
Since the [`Module.prototype._compile`](https://github.com/nodejs/node/blob/b010c8716498dca398e61c388859fea92296feb3/lib/module.js#L373) is using a variable `resolvedArgv` declared outside of the function, the work-around here is to re-insert it when we're executing in "debug" mode so that it won't break the execution and make the test failed.

Closes #17
